### PR TITLE
Correct notation for data size

### DIFF
--- a/cli/download.js
+++ b/cli/download.js
@@ -50,7 +50,7 @@ if (parameters.v) {
       return ;
     }
     if (!progress) {
-      progress = new  ProgressBar(`  Downloading [:bar] ${chalk.yellow(':current kb/:total kb')}`, {
+      progress = new  ProgressBar(`  Downloading [:bar] ${chalk.yellow(':current KiB/:total KiB')}`, {
         complete: '=',
         incomplete: '_',
         width: 50,


### PR DESCRIPTION
Small 'b' means bits in terms of data size. Which is not intended here, 'KiB' means 1024 Bytes
